### PR TITLE
Add Windows / PowerShell support via set_title.ps1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This script will:
 claude-code install terminal-title.skill
 ```
 
-### Manual Install
+### Manual Install (macOS / Linux)
 
 ```bash
 # Create skills directory if it doesn't exist
@@ -54,6 +54,21 @@ unzip terminal-title.skill -d ~/.claude/skills/
 # Make script executable
 chmod +x ~/.claude/skills/terminal-title/scripts/set_title.sh
 ```
+
+### Manual Install (Windows)
+
+```powershell
+# Create skills directory if it doesn't exist
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.claude\skills" | Out-Null
+
+# Extract the skill
+Expand-Archive -Force terminal-title.skill "$env:USERPROFILE\.claude\skills\"
+
+# Quick smoke test — your Windows Terminal tab title should change
+& "$env:USERPROFILE\.claude\skills\terminal-title\scripts\set_title.ps1" "Test: Install OK"
+```
+
+The Windows version uses the .NET `[Console]::Title` API (Win32 `SetConsoleTitle`) rather than ANSI escape sequences, because Claude Code's Bash tool strips control bytes from subprocess stdout before they reach the host terminal. See the "Compatibility" section for details.
 
 ### Uninstall
 
@@ -123,6 +138,7 @@ This produces titles like: `🤖 Claude | my-project | Build: Dashboard UI`
 ### Fully Tested & Working
 - ✅ macOS Terminal.app + zsh (with setup-zsh.sh)
 - ✅ iTerm2 (macOS)
+- ✅ Windows Terminal + PowerShell (via the bundled `set_title.ps1`)
 
 ### Should Work (Not Extensively Tested)
 - ⚠️ Alacritty
@@ -130,11 +146,17 @@ This produces titles like: `🤖 Claude | my-project | Build: Dashboard UI`
 - ⚠️ GNOME Terminal (Linux)
 - ⚠️ Konsole (KDE)
 - ⚠️ Windows Terminal + WSL
+- ⚠️ Windows Console Host (conhost.exe) — PowerShell variant should work; not benchmarked
 
 ### Known Limitations
 - ❌ Plain bash without precmd support (titles won't persist across prompts)
-- ❌ Windows native terminals (Command Prompt, PowerShell) - ANSI escape sequences not universally supported
 - ❌ Very old terminal emulators without ANSI support
+
+### Windows: Why a Second Script?
+
+On Windows, the bash version's `printf '\033]0;...\007'` approach does **not** work when Claude Code invokes the script through its Bash tool, even though Windows Terminal itself fully supports OSC 0 title sequences. The reason is that Claude Code's Bash tool sanitizes control bytes from subprocess stdout before display, so the escape never reaches the host terminal.
+
+The Windows-specific `set_title.ps1` sidesteps this by calling `[Console]::Title = ...` (which wraps the Win32 `SetConsoleTitle` API). The hook PowerShell subprocess inherits Claude Code's console, so the title-set call hits the parent terminal directly without going through stdout.
 
 ### Session Behavior
 When you set a title in Terminal A and open Terminal B within 5 minutes, Terminal B will initially inherit Terminal A's title. Once Claude Code runs in Terminal B and sets a new title, each terminal will maintain its own title independently. This is by design - it prevents stale titles from appearing in new terminals while preserving titles within active sessions.
@@ -178,7 +200,20 @@ When you set a title in Terminal A and open Terminal B within 5 minutes, Termina
 Your terminal may not support ANSI escape sequences. Try:
 - **macOS:** Use iTerm2 or built-in Terminal.app
 - **Linux:** Use GNOME Terminal, Alacritty, or Kitty
-- **Windows:** Use Windows Terminal or WSL with a compatible terminal
+- **Windows:** Use the bundled `set_title.ps1` (PowerShell) rather than `set_title.sh` (bash). The bash version's escape-sequence approach is filtered by Claude Code's Bash tool on Windows.
+
+### Windows: Title Not Updating?
+
+1. **Verify the PowerShell script exists:**
+   ```powershell
+   Test-Path "$env:USERPROFILE\.claude\skills\terminal-title\scripts\set_title.ps1"
+   ```
+2. **Test manually from Windows Terminal:**
+   ```powershell
+   & "$env:USERPROFILE\.claude\skills\terminal-title\scripts\set_title.ps1" "Test: Manual"
+   # Your tab title should immediately show "<cwd> | Test: Manual"
+   ```
+3. **Confirm SKILL.md is dispatching to the .ps1, not the .sh.** Open `SKILL.md` and verify the Implementation section mentions the PowerShell path.
 
 ### Skill Not Triggering Automatically?
 

--- a/temp_extract/terminal-title/SKILL.md
+++ b/temp_extract/terminal-title/SKILL.md
@@ -87,10 +87,17 @@ Keep titles concise, actionable, and immediately recognizable.
 
 ## Implementation
 
-**Execute the title script:**
+**On macOS / Linux** — execute the bash script via the Bash tool:
 ```bash
 bash scripts/set_title.sh "Your Title Here"
 ```
+
+**On Windows** — execute the PowerShell script via the PowerShell tool:
+```powershell
+& "$env:USERPROFILE\.claude\skills\terminal-title\scripts\set_title.ps1" "Your Title Here"
+```
+
+Pick the script that matches the host OS. If unsure, the working directory's path style is a reliable hint (`/c/Users/...` or `C:\Users\...` → Windows).
 
 **Example workflow:**
 ```bash
@@ -106,11 +113,13 @@ bash scripts/set_title.sh "Test: Payment Module"
 
 ## Script Details
 
-The `scripts/set_title.sh` script uses ANSI escape sequences to set the terminal title. It's compatible with:
+`scripts/set_title.sh` (macOS / Linux) uses ANSI OSC escape sequences. Compatible with:
 - macOS Terminal
 - iTerm2
 - Alacritty
 - Most modern terminal emulators (xterm, rxvt, screen, tmux)
+
+`scripts/set_title.ps1` (Windows) uses the .NET `[Console]::Title` API (Win32 `SetConsoleTitle`). Compatible with Windows Terminal, Windows Console Host (conhost), and ConPTY-hosted terminals. The bash script's ANSI-escape approach does not work on Windows when invoked through Claude Code's Bash tool, because the tool strips control bytes from subprocess stdout before they can reach the host terminal — the PowerShell version bypasses stdout entirely by calling SetConsoleTitle on the inherited console.
 
 The script accepts a single argument (the title string) and exits silently if no title is provided (fail-safe behavior).
 

--- a/temp_extract/terminal-title/scripts/set_title.ps1
+++ b/temp_extract/terminal-title/scripts/set_title.ps1
@@ -1,0 +1,43 @@
+# Terminal title setter for Claude Code on Windows.
+#
+# Usage:
+#   set_title.ps1 "Your Title Here"            # arg mode (skill invocation)
+#   '{"prompt":"..."}' | set_title.ps1          # stdin mode (UserPromptSubmit hook)
+#
+# Sets the hosting console's title to "<cwd-name> | <title>". The optional
+# environment variable CLAUDE_TITLE_PREFIX is prepended if set.
+#
+# Why this script exists alongside set_title.sh: on Windows, Claude Code's
+# Bash tool strips control bytes (including ESC) from subprocess stdout
+# before display, so the printf '\033]0;...\007' approach in the .sh
+# version never reaches the host terminal. This script bypasses the
+# stdout channel entirely by calling [Console]::Title, which wraps the
+# Win32 SetConsoleTitle API on the inherited console.
+
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [string]$Title
+)
+
+if (-not $Title -and [Console]::IsInputRedirected) {
+    try {
+        $payload = [Console]::In.ReadToEnd() | ConvertFrom-Json -ErrorAction Stop
+        $Title = $payload.prompt
+    } catch {
+        exit 0
+    }
+}
+
+if (-not $Title) { exit 0 }
+
+$clean = ($Title -replace '[\x00-\x1F]+', ' ' -replace '\s+', ' ').Trim()
+if ($clean.Length -gt 60) { $clean = $clean.Substring(0, 60).TrimEnd() + '...' }
+if (-not $clean) { exit 0 }
+
+$dir = Split-Path -Leaf (Get-Location).Path
+$prefix = $env:CLAUDE_TITLE_PREFIX
+
+$final = if ($prefix) { "$prefix $dir | $clean" } else { "$dir | $clean" }
+
+try { [Console]::Title = $final } catch { }


### PR DESCRIPTION
## Summary

Adds Windows support to the terminal-title skill alongside the existing macOS/Linux bash implementation. The README currently lists "Windows native terminals (Command Prompt, PowerShell)" as a known limitation — this PR removes that limitation for Windows Terminal and the modern Windows console.

## Why a second script

On Windows, the bash version's `printf '\033]0;...\007'` approach does **not** work when Claude Code invokes the script through its Bash tool, even though Windows Terminal itself fully supports OSC 0 title sequences. The reason: Claude Code's Bash tool sanitizes control bytes from subprocess stdout before display, so the ESC byte never reaches the host terminal. I verified this empirically — the resulting tool output is the literal text `]0;...` with the ESC stripped.

The new `scripts/set_title.ps1` sidesteps this by calling `[Console]::Title = ...`, which wraps the Win32 `SetConsoleTitle` API on the inherited console. Because the hook PowerShell subprocess inherits Claude Code's console, the title-set call hits the host terminal directly — no stdout channel involved, no sanitization possible.

## What's in the PR

- **`scripts/set_title.ps1`** (new) — PowerShell mirror of `set_title.sh`. Same feature set: `CLAUDE_TITLE_PREFIX` env var, cwd-name prefix, fail-safe on empty input, 60-char cap, control-byte sanitization. Also accepts JSON on stdin so users can optionally wire it as a `UserPromptSubmit` hook for prompt-based auto-titling (not required for the skill to work).
- **`SKILL.md`** — Implementation section now dispatches by OS. macOS/Linux → bash via Bash tool; Windows → PowerShell via PowerShell tool. Working-directory path style is suggested as the OS hint if Claude is unsure.
- **`README.md`** — Windows manual-install block, expanded compatibility matrix (Windows Terminal + PowerShell promoted to "Fully Tested"), new "Why a Second Script?" explainer, Windows troubleshooting section.

## What's not in the PR

- `terminal-title.skill` (the binary zip) is untouched. The source-of-truth in `temp_extract/` has the new files; I left the zip rebuild to you on release so you can use whatever tooling you normally do and decide on the LICENSE/CHANGELOG/VERSION bump.
- No changes to `install-and-test.sh`, `setup-zsh.sh`, or `uninstall.sh` — those are Mac/Linux-specific and the Windows install is short enough to live in the README. I can add an `install.ps1` in a follow-up if you'd like.

## Testing

- Manually verified `[Console]::Title = "..."` from a child PowerShell process updates the parent Windows Terminal tab title (the load-bearing assumption).
- Manually verified `set_title.ps1 "Test"` and `set_title.ps1` (no-arg, fail-safe) behaviors.
- Verified the JSON-stdin path with a piped-payload simulation (real-world testing of this requires it being wired as a hook, which is a user-config decision outside the skill scope).

Test plan for reviewer:
- [ ] On Windows: extract `terminal-title.skill` to `~/.claude/skills/` (after rebuilding with the new files), then `& "$env:USERPROFILE\.claude\skills\terminal-title\scripts\set_title.ps1" "Test"` — Windows Terminal tab title should change.
- [ ] On Mac/Linux: existing `bash scripts/set_title.sh "Test"` flow unchanged, should still work as before.
- [ ] Skill invocation: ask Claude Code to start a new task; it should run the appropriate script per OS based on the updated SKILL.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
